### PR TITLE
OSCR-849. Enabling the option to use HTTPS/2 for REST calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.openfeign</groupId>
     <artifactId>feign-vertx</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <packaging>jar</packaging>
 
     <name>feign-vertx</name>

--- a/src/main/java/feign/AsynchronousMethodHandler.java
+++ b/src/main/java/feign/AsynchronousMethodHandler.java
@@ -13,6 +13,7 @@ import feign.vertx.VertxHttpClient;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.http.HttpClientOptions;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -37,7 +38,7 @@ class AsynchronousMethodHandler
   private final Logger logger;
   private final Logger.Level logLevel;
   private final RequestTemplate.Factory buildTemplateFromArgs;
-  private final Request.Options options;
+  private final HttpClientOptions options;
   private final Decoder decoder;
   private final ErrorDecoder errorDecoder;
   private final boolean decode404;
@@ -51,7 +52,7 @@ class AsynchronousMethodHandler
       Logger.Level logLevel,
       MethodMetadata metadata,
       RequestTemplate.Factory buildTemplateFromArgs,
-      Request.Options options,
+      HttpClientOptions options,
       Decoder decoder,
       ErrorDecoder errorDecoder,
       boolean decode404) {
@@ -283,7 +284,7 @@ class AsynchronousMethodHandler
         final Target<?> target,
         final MethodMetadata metadata,
         final RequestTemplate.Factory buildTemplateFromArgs,
-        final Request.Options options,
+        final HttpClientOptions options,
         final Decoder decoder,
         final ErrorDecoder errorDecoder) {
       return new AsynchronousMethodHandler(

--- a/src/main/java/feign/vertx/VertxHttpClient.java
+++ b/src/main/java/feign/vertx/VertxHttpClient.java
@@ -36,15 +36,14 @@ public final class VertxHttpClient {
    * Executes HTTP request and returns {@link Future} with response.
    *
    * @param request request
-   * @param options request options
+   * @param options {@link HttpClientOptions}
    *
    * @return future of HTTP response
    */
   public Future<Response> execute(
       final Request request,
-      final Request.Options options) {
-    final HttpClientOptions requestOptions = makeHttpClientOptions(options);
-    final HttpClient client = vertx.createHttpClient(requestOptions);
+      final HttpClientOptions options) {
+    final HttpClient client = vertx.createHttpClient(options);
     final HttpClientRequest httpClientRequest;
 
     try {
@@ -120,20 +119,6 @@ public final class VertxHttpClient {
     return httpClientRequest;
   }
 
-  /**
-   * Transforms per-request provided feign {@link Request.Options} into Vert.x
-   * {@link HttpClientOptions}.
-   *
-   * @param options feign options
-   *
-   * @return options for vert.x HTTP client
-   */
-  private HttpClientOptions makeHttpClientOptions(
-      final Request.Options options) {
-    return new HttpClientOptions()
-        .setConnectTimeout(options.connectTimeoutMillis())
-        .setIdleTimeout(options.readTimeoutMillis());
-  }
 
   /**
    * Parses {@link HttpMethod} from string.

--- a/src/test/java/feign/vertx/VertxHttpOptionsTest.java
+++ b/src/test/java/feign/vertx/VertxHttpOptionsTest.java
@@ -1,0 +1,144 @@
+package feign.vertx;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.Logger;
+import feign.Request;
+import feign.VertxFeign;
+import feign.jackson.JacksonDecoder;
+import feign.slf4j.Slf4jLogger;
+import feign.vertx.testcase.IcecreamServiceApi;
+import feign.vertx.testcase.domain.*;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test the new capability of Vertx Feign client to support both Feign
+ * Request.Options (regression) and the new HttpClientOptions configuration.
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxHttpOptionsTest {
+  private Vertx vertx = Vertx.vertx();
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(8089);
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private String flavorsStr;
+
+  @Before
+  public void setUp() throws Exception {
+    /* Given */
+  flavorsStr = Arrays
+            .stream(Flavor.values())
+            .map(flavor -> "\"" + flavor + "\"")
+            .collect(Collectors.joining(", ", "[ ", " ]"));
+  }
+
+
+  /**
+   * Test the Vert.x HttpClientOptions version of the Vert.x Feign Client.
+   * This is useful for use-cases like HTTPS/2 or gzip compressed responses.
+   * @param context Test Context
+   */
+  @Test
+  public void testHttpClientOptions(TestContext context) {
+    // NOTE: We cannot use HTTPS/2 because Wiremock 2.1.0-beta uses Jetty 9.2.13.v20150730.
+    //       Jetty 9.3 is required for HTTPS/2. So we use HttpClientOptions.TryUseCompression(true)
+    //       instead to verify we're using the Vert.x HttpClientOptions object.
+    HttpClientOptions options = new HttpClientOptions().
+            setTryUseCompression(true). // Attribute under test, not available with Feign Request.Options
+            setConnectTimeout(5000).
+            setIdleTimeout(5000);
+
+    IcecreamServiceApi client = VertxFeign
+            .builder()
+            .vertx(vertx)
+            .options(options) // New feature! Accepts HttpClientOptions
+            .decoder(new JacksonDecoder(TestUtils.MAPPER))
+            .logger(new Slf4jLogger())
+            .logLevel(Logger.Level.FULL)
+            .target(IcecreamServiceApi.class, "http://localhost:8089");
+
+    stubFor(get(urlEqualTo("/icecream/flavors"))
+            .withHeader("Accept", equalTo("application/json"))
+            .withHeader("Accept-Encoding", equalTo("deflate, gzip")) // Test setTryUseCompression(true) affected the request
+            .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(flavorsStr)));
+
+    testClient(client, context);
+  }
+
+
+  /**
+   * Test the Feign Request Options version of the Vert.x Feign Client.
+   * This proves regression is not broken for existing use-cases.
+   * @param context Test Context
+   */
+  @Test
+  public void testRequestOptions(TestContext context) {
+    IcecreamServiceApi client = VertxFeign
+            .builder()
+            .vertx(vertx)
+            .options(new Request.Options(5000,5000) ) // Plain old Feign Request.Options (regression)
+            .decoder(new JacksonDecoder(TestUtils.MAPPER))
+            .logger(new Slf4jLogger())
+            .logLevel(Logger.Level.FULL)
+            .target(IcecreamServiceApi.class, "http://localhost:8089");
+
+    stubFor(get(urlEqualTo("/icecream/flavors"))
+            .withHeader("Accept", equalTo("application/json"))
+            .withHeader("Accept-Encoding", absent()) // Test that Accept-Encoding is missing (since we're using Request.Options)
+            .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(flavorsStr)));
+
+    testClient(client, context);
+  }
+
+
+  /**
+   * Test the provided client for the correct results
+   * @param client Feign client instance
+   * @param context Test Context
+   */
+  private void testClient(IcecreamServiceApi client, TestContext context) {
+    Async async = context.async();
+
+    client.getAvailableFlavors().setHandler(res -> {
+      if (res.succeeded()) {
+        Collection<Flavor> flavors = res.result();
+
+        try {
+          assertThat(flavors)
+                  .hasSize(Flavor.values().length)
+                  .containsAll(Arrays.asList(Flavor.values()));
+          async.complete();
+        } catch (Throwable exception) {
+          context.fail(exception);
+        }
+      } else {
+        context.fail(res.cause());
+      }
+    });
+  }
+}


### PR DESCRIPTION
This is a minor adjustment to the feign-vertx integration to inject the Vert.x native HttpClientOptions object in addition to the previous Request.Options (for regression). The side effect is the ability to configure HTTPS/2 for feign-vertx! :-)