### PR TITLE
Socket Leak Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <slf4j-log4j12.version>1.8.0-beta0</slf4j-log4j12.version>
 
         <!-- Plugins -->
-        <jacoco-plugin.version>0.7.7.201606060606</jacoco-plugin.version>
+        <jacoco-plugin.version>0.7.9</jacoco-plugin.version>
         <coveralls-plugin.version>4.1.0</coveralls-plugin.version>
 
         <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
@@ -215,6 +215,43 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <!-- Jacoco Code Coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Sets the path to the file which contains the execution data. -->
+
+                            <dataFile>target/jacoco.exec</dataFile>
+                            <!-- Sets the output directory for the code coverage report. -->
+                            <outputDirectory>target/jacoco-ut</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <!-- Push binary to JCenter -->

--- a/src/main/java/feign/vertx/VertxHttpClient.java
+++ b/src/main/java/feign/vertx/VertxHttpClient.java
@@ -30,6 +30,8 @@ import java.util.stream.StreamSupport;
 @SuppressWarnings("unused")
 public final class VertxHttpClient {
   private final Vertx vertx;
+  
+  private HttpClient client = null;
 
   public VertxHttpClient(final Vertx vertx) {
     this.vertx = checkNotNull(vertx, "Argument vertx must not be null");
@@ -47,11 +49,14 @@ public final class VertxHttpClient {
     checkNotNull(request, "Argument request must be not null");
     checkNotNull(options, "Argument options must be not null");
 
-    final HttpClient client = vertx.createHttpClient(options);
+    if (this.client == null) {
+      this.client = vertx.createHttpClient(options);
+    }
+
     final HttpClientRequest httpClientRequest;
 
     try {
-      httpClientRequest = makeHttpClientRequest(request, client);
+      httpClientRequest = makeHttpClientRequest(request, this.client);
     } catch (final MalformedURLException unexpectedException) {
       return Future.failedFuture(unexpectedException);
     }

--- a/src/test/java/feign/vertx/VertxHttp11ClientLeakFixTest.java
+++ b/src/test/java/feign/vertx/VertxHttp11ClientLeakFixTest.java
@@ -1,0 +1,99 @@
+package feign.vertx;
+
+import feign.VertxFeign;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.vertx.testcase.HelloServiceAPI;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.*;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+
+/**
+ * Verify that Feign-Vertx does not leak sockets upon each request
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxHttp11ClientLeakFixTest {
+  private Vertx vertx = Vertx.vertx();
+  private HttpServer httpServer = null;
+
+  private HashSet<HttpConnection> connections = new HashSet<>();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testHttpClientIssue(TestContext context) {
+
+    Async async = context.async();
+
+    HttpServerOptions serverOptions =
+            new HttpServerOptions()
+                    .setLogActivity(true)
+                    .setPort(8090)
+                    .setSsl(false);
+
+    httpServer = this.vertx.createHttpServer(serverOptions);
+
+    // add a request handler and save the connections.
+    httpServer.requestHandler(request -> {
+      if (request.connection() != null)
+      {
+        this.connections.add(request.connection());
+      }
+      request.response().end("Hello world");
+    });
+
+    httpServer.listen(res -> {
+      if (res.failed()) {
+        context.assertTrue(res.failed(), "Server failed to start");
+      } else {
+        // for HTTP 1.1 test, set up the pool size to 3. Then in the server side, there should be only 3 connections created per client.
+        HttpClientOptions options = new HttpClientOptions();
+        options.setMaxPoolSize(3);
+
+        HelloServiceAPI client = VertxFeign
+            .builder()
+            .vertx(this.vertx)
+            .options(options)
+            .encoder(new JacksonEncoder())
+            .decoder(new JacksonDecoder())
+            .target(HelloServiceAPI.class, "http://localhost:8090");
+
+        // run 10 times call to the server, then check if there are 10 connections created in server or not.
+        for (int numToCall = 10; numToCall > 0; numToCall--) {
+
+          /* When */
+          client.hello().setHandler(response -> {
+            /* Then */
+            if (response.succeeded()) {
+                async.complete();
+            } else {
+              context.fail(response.cause());
+            }
+          });
+        }
+      }
+    });
+  }
+
+  @After
+  public void after(TestContext context) {
+    System.out.println("Connection created in server " + this.connections.size());
+
+    // before the fix of HttpClient issue in VertxHttpClient, the server will create 10 connections for 10 requests.
+    // after the fix of the issue, server should only create 3 connection per same client.
+    context.assertTrue(this.connections.size() == 3);
+
+    // Stop the server
+    httpServer.close();
+  }
+}

--- a/src/test/java/feign/vertx/VertxHttp11ClientReconnectTest.java
+++ b/src/test/java/feign/vertx/VertxHttp11ClientReconnectTest.java
@@ -1,0 +1,219 @@
+package feign.vertx;
+
+import feign.VertxFeign;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.vertx.testcase.HelloServiceAPI;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Verify that Feign-Vertx are resilient to a server disconnect event.
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxHttp11ClientReconnectTest {
+  protected Vertx vertx = Vertx.vertx();
+  protected HttpServer httpServer = null;
+  HelloServiceAPI client = null;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  /**
+   * Create a Feign Vertx client that is built once and used several times
+   * during positive and negative test cases.
+   * @param context
+   */
+  @Before
+  public void before(TestContext context) {
+    // for HTTP 1.1 test, set up the pool size to 3. Then in the server side, there should be only 3 connections created per client.
+    HttpClientOptions options = new HttpClientOptions();
+    options.setMaxPoolSize(3);
+
+    client = VertxFeign
+        .builder()
+        .vertx(this.vertx)
+        .options(options)
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
+        .target(HelloServiceAPI.class, "http://localhost:8090");
+  }
+
+  /**
+   * Shutdown the server
+   * @param context
+   */
+  @After
+  public void after(TestContext context) {
+    closeServer();
+  }
+
+
+  /**
+   * Create an HTTP Server and return a future for the startup result
+   * @return Future for handling the serve open event
+   */
+  protected Future<HttpServer> createServer() {
+    Future<HttpServer> ret = Future.future();
+
+    HttpServerOptions serverOptions =
+        new HttpServerOptions()
+            .setLogActivity(true)
+            .setPort(8090)
+            .setSsl(false);
+
+    httpServer = this.vertx.createHttpServer(serverOptions);
+
+    // Simple 200 handler
+    httpServer.requestHandler( req -> req.response().setStatusCode(200).end("Success!") );
+
+    // Listen! delegating to the future
+    httpServer.listen( ret.completer() );
+
+    return ret;
+  }
+
+
+  /**
+   * Verify Feign-Vertx's HttpClient automatically reconnects
+   * to a server that severed connections temporarily.
+   * @param context
+   */
+  @Test
+  public void testHttpReconnectTemporary(TestContext context) {
+    // Async test context
+    Async async = context.async();
+
+    Future<Void> futSuccess = Future.future();
+
+    // 1. Start the server
+    // 2. Send a Volley of Requests to the server
+    // 3. Close server!
+    // 4. Start server again
+    // 5. Send another Volley of Requests to the server
+    // If all goes well the testFuture will signal success
+    createServer()
+        .compose( result -> requestVolley() )
+        .compose( result -> closeServer() )
+        .compose( result -> createServer() )
+        .compose( result -> requestVolley() )
+        .compose( result -> futSuccess.complete(), futSuccess);
+
+
+    // This future will be triggered at the end of the test
+    futSuccess.setHandler( result -> {
+      if (result.succeeded()) {
+        async.complete(); // success
+      } else {
+        context.fail(result.cause());
+      }
+    });
+  }
+
+  /**
+   * Verify Feign-Vertx's HttpClient reconnects to a server
+   * after an extended outage.
+   * @param context
+   */
+  @Test
+  public void testHttpReconnectOutage(TestContext context) {
+    // Async test context
+    Async async = context.async();
+
+    Future<Void> futFailed = Future.future();
+    Future<Void> futSuccess = Future.future();
+
+    // 1. Start the server
+    // 2. Send a Volley of Requests to the server
+    // 3. Close server!
+    // 4. Send another Volley of Requests to the server
+    // Expect a failure and absorb it with futFailed
+    createServer()
+        .compose( result -> requestVolley() )
+        .compose( result -> closeServer() )
+        // do not restart the server, causing a failure on the next request
+        .compose( result -> requestVolley() )
+        .compose( result -> futFailed.complete(), futFailed);
+
+    // We expect a failure when this future is called.
+    futFailed.setHandler( result -> {
+      if ( result.failed() ) {
+        // We expect HTTP/1.1 "Connection was refused" or HTTP/2 "Connection was closed"
+        if ( result.cause().getMessage().startsWith("Connection ") ) {
+          // This is what we expect for this future!
+          // 1. Start server again
+          // 2. Re-using the same Feign-Vertx client as the failure above
+          //    we send a new volley of requests
+          // If all goes well futSuccess will succeed and end the unit test
+          createServer()
+              .compose( res2 -> requestVolley() )
+              .compose( res2 -> futSuccess.complete(), futSuccess );
+        } else {
+          // Problem, we received an unexpected error
+          context.fail("futFailed should have seen a \"Connection refused\" but received a \""+result.cause().getMessage()+"\"");
+        }
+      }
+      else {
+        // Problem, we unexpectedly succeeded!
+        context.fail("futFailed should have received a failure but it actually succeeded!");
+      }
+    });
+
+    // This is the final future that will be triggered upon a positive test case
+    futSuccess.setHandler( result -> {
+      if (result.succeeded()) {
+        async.complete(); // success
+      } else {
+        context.fail(result.cause());
+      }
+    });
+  }
+
+
+  /**
+   * This issues ten requests to the server via a shared
+   * long lived Feign Vertx client.
+   * @return
+   */
+  private CompositeFuture requestVolley() {
+    List<Future> requests = new ArrayList<>(10);
+
+    // Initiate 10 requests
+    for( int i=0; i<10; i++ ) {
+      Future<feign.Response> request = Future.future();
+      client.hello().setHandler(request.completer());
+      requests.add(request);
+    }
+
+    // Composite future for all of the requests
+    return CompositeFuture.all(requests);
+  }
+
+
+  /**
+   * Close the server connection
+   * @return future for close completion
+   */
+  public Future<Void> closeServer() {
+    // Close server
+    Future<Void> fut = Future.future();
+    httpServer.close(fut.completer());
+    return fut;
+  }
+}

--- a/src/test/java/feign/vertx/VertxHttp2ClientLeakFixTest.java
+++ b/src/test/java/feign/vertx/VertxHttp2ClientLeakFixTest.java
@@ -1,0 +1,102 @@
+package feign.vertx;
+
+import feign.*;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.vertx.testcase.HelloServiceAPI;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+
+/**
+ * Verify that Feign-Vertx does not leak sockets upon each request
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxHttp2ClientLeakFixTest {
+  private Vertx vertx = Vertx.vertx();
+  private HttpServer httpServer = null;
+
+  private HashSet<HttpConnection> connections = new HashSet<>();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testHttp2ClientIssue(TestContext context) {
+
+    Async async = context.async();
+
+    HttpServerOptions serverOptions =
+            new HttpServerOptions()
+                    .setLogActivity(true)
+                    .setPort(8091)
+                    .setSsl(false);
+
+    httpServer = this.vertx.createHttpServer(serverOptions);
+
+    // add a request handler and save the connections.
+    httpServer.requestHandler(request -> {
+      if (request.connection() != null)
+      {
+        this.connections.add(request.connection());
+      }
+      request.response().end("Hello world");
+    });
+
+    httpServer.listen(res -> {
+      if (res.failed()) {
+        context.assertTrue(res.failed(), "Server failed to start");
+      } else {
+        // for HTTP2 test, set up the protocol and the pool size to 1.
+        HttpClientOptions options = new HttpClientOptions();
+        options.setProtocolVersion(HttpVersion.HTTP_2).setHttp2MaxPoolSize(1);
+
+        HelloServiceAPI client = VertxFeign
+            .builder()
+            .vertx(this.vertx)
+            .options(options)
+            .encoder(new JacksonEncoder())
+            .decoder(new JacksonDecoder())
+            .target(HelloServiceAPI.class, "http://localhost:8091");
+
+        // run 10 times call to the server, then check if there are 10 connections created in server or not.
+        for (int numToCall = 10; numToCall > 0; numToCall--) {
+          /* When */
+          client.hello().setHandler(response -> {
+            /* Then */
+            if (response.succeeded()) {
+              async.complete();
+            } else {
+              context.fail(response.cause());
+            }
+          });
+        }
+      }
+    });
+  }
+
+  @After
+  public void after(TestContext context) {
+    System.out.println("Connection created in server " + this.connections.size());
+
+    // before the fix of HttpClient issue in VertxHttpClient, the server will create 10 connections for 10 requests.
+    // after the fix of the issue, server should only create 1 connection per same client.
+    context.assertTrue(this.connections.size() == 1);
+
+    // Stop the server
+    httpServer.close();
+  }
+}

--- a/src/test/java/feign/vertx/VertxHttp2ClientReconnectTest.java
+++ b/src/test/java/feign/vertx/VertxHttp2ClientReconnectTest.java
@@ -1,0 +1,68 @@
+package feign.vertx;
+
+import feign.VertxFeign;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.vertx.testcase.HelloServiceAPI;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+/**
+ * Verify that Feign-Vertx are resilient to a server disconnect event.
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxHttp2ClientReconnectTest extends VertxHttp11ClientReconnectTest {
+  /**
+   * Create a Feign Vertx client that is built once and used several times
+   * during positive and negative test cases.
+   * @param context
+   */
+  @Before
+  public void before(TestContext context) {
+    // for HTTP2 test, set up the protocol and the pool size to 1.
+    HttpClientOptions options = new HttpClientOptions();
+    options
+        .setProtocolVersion(HttpVersion.HTTP_2)
+        .setHttp2MaxPoolSize(1);
+
+    client = VertxFeign
+        .builder()
+        .vertx(this.vertx)
+        .options(options)
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
+        .target(HelloServiceAPI.class, "http://localhost:8091");
+  }
+
+
+  /**
+   * Create an HTTP Server and return a future for the startup result
+   * @return Future for handling the serve open event
+   */
+  protected Future<HttpServer> createServer() {
+    Future<HttpServer> ret = Future.future();
+
+    HttpServerOptions serverOptions =
+        new HttpServerOptions()
+            .setLogActivity(true)
+            .setPort(8091)
+            .setSsl(false);
+
+    httpServer = this.vertx.createHttpServer(serverOptions);
+
+    // Simple 200 handler
+    httpServer.requestHandler( req -> req.response().setStatusCode(200).end("Success!") );
+
+    // Listen! delegating to the future
+    httpServer.listen( ret.completer() );
+
+    return ret;
+  }
+}

--- a/src/test/java/feign/vertx/testcase/HelloServiceAPI.java
+++ b/src/test/java/feign/vertx/testcase/HelloServiceAPI.java
@@ -1,0 +1,20 @@
+package feign.vertx.testcase;
+
+import feign.Headers;
+import feign.RequestLine;
+import feign.Response;
+import feign.vertx.testcase.domain.Bill;
+import io.vertx.core.Future;
+
+/**
+ * Example of an API to to test number of Http2 connections of Feign.
+ *
+ * @author James Xu
+ */
+@Headers({ "Accept: application/json" })
+public interface HelloServiceAPI {
+
+  @RequestLine("GET /hello")
+  Future<Response> hello();
+
+}


### PR DESCRIPTION
During load and stress testing we noticed 28K sockets in the ESTABLISHED state. After further investigation we noticed HttpClient is created for every request without being removed.

The solution in this PR is to re-use the HttpClient for efficiency (socket recycling) and to prevent the leak (ephemeral socket exhaustion).

We've added comprehensive unit tests to verify the leak is fixed for HTTP/1.1 and HTTP/2. We also test adverse conditions to ensure there are no bugs when the server is disconnected for HTTP/1.1 and HTTP/2.0.