### PR TITLE
Enhance Feign-Vertx to use an optional CircuitBreak and @Fallback annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
             <version>${slf4j-log4j12.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-circuit-breaker</artifactId>
+            <version>${vertx.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/feign/AsynchronousMethodHandler.java
+++ b/src/main/java/feign/AsynchronousMethodHandler.java
@@ -9,14 +9,20 @@ import feign.codec.DecodeException;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 import feign.vertx.VertxHttpClient;
+import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Method handler for asynchronous HTTP requests via {@link VertxHttpClient}.
@@ -39,7 +45,15 @@ final class AsynchronousMethodHandler implements MethodHandler {
   private final Decoder decoder;
   private final ErrorDecoder errorDecoder;
   private final boolean decode404;
+  private final CircuitBreaker circuitBreaker;
+  private       Method thisMethod;
+  private       Method fallbackMethod;
+  private       Object fallbackInstance;
 
+  // This data structure allows us to cache fallback class instances for quick execution
+  // MT safe, enabling multiple vertical processors to access this safely
+  private final static ConcurrentHashMap<Class, Object> fallbackInstanceCache = new ConcurrentHashMap<>();
+  
   private AsynchronousMethodHandler(
       final Target<?> target,
       final VertxHttpClient client,
@@ -51,7 +65,8 @@ final class AsynchronousMethodHandler implements MethodHandler {
       final RequestTemplate.Factory buildTemplateFromArgs,
       final Decoder decoder,
       final ErrorDecoder errorDecoder,
-      final boolean decode404) {
+      final boolean decode404,
+      CircuitBreaker circuitBreaker) {
     this.target = target;
     this.client = client;
     this.retryer = retryer;
@@ -63,6 +78,7 @@ final class AsynchronousMethodHandler implements MethodHandler {
     this.errorDecoder = errorDecoder;
     this.decoder = decoder;
     this.decode404 = decode404;
+    this.circuitBreaker = circuitBreaker;
   }
 
   @Override
@@ -71,8 +87,8 @@ final class AsynchronousMethodHandler implements MethodHandler {
     final RequestTemplate template = buildTemplateFromArgs.create(argv);
     final Retryer retryer = this.retryer.clone();
 
-    final ResultHandlerWithRetryer handler = new ResultHandlerWithRetryer(template, retryer);
-    executeAndDecode(template).setHandler(handler);
+    final ResultHandlerWithRetryer handler = new ResultHandlerWithRetryer(template, argv, retryer);
+    executeAndDecode(template, argv).setHandler(handler);
 
     return handler.getResultFuture();
   }
@@ -82,22 +98,29 @@ final class AsynchronousMethodHandler implements MethodHandler {
    * Result or occurred error wrapped in returned Future.
    *
    * @param template  request template
+   * @param argv request argument for use when calling the fallback method
    *
    * @return future with decoded result or occurred error
    */
-  private Future<Object> executeAndDecode(final RequestTemplate template) {
+  private Future<Object> executeAndDecode(final RequestTemplate template, final Object[] argv) {
     final Request request = targetRequest(template);
     final Future<Object> decodedResultFuture = Future.future();
+    final AsynchronousMethodHandler that = this;
 
     logRequest(request);
 
     final Instant start = Instant.now();
 
-    client.execute(request).setHandler(res -> {
+    /**
+     * Define the handler as a variable as we need to use it in two
+     * different scenarios towards the end of the function.
+     */
+    final Handler<AsyncResult<Response>> handler = res -> {
       boolean shouldClose = true;
 
       final long elapsedTime = Duration.between(start, Instant.now()).toMillis();
 
+      // Process the response!
       if (res.succeeded()) {
 
         /* Just as executeAndDecode in SynchronousMethodHandler but wrapped in Future */
@@ -157,8 +180,82 @@ final class AsynchronousMethodHandler implements MethodHandler {
           decodedResultFuture.fail(res.cause());
         }
       }
-    });
+    };
 
+    /**
+     * Now execute the REST call
+     */
+    if ( null == circuitBreaker ) {
+      // No breaker, use a traditional call with the handler defined above
+      client.execute(request).setHandler(handler);
+    }
+    else {
+      // Breaker present, execute the REST call fallback semantics
+      circuitBreaker.executeWithFallback(
+          //
+          // Operation to be performed. (breakerFuture tells us the state of the breaker)
+          //
+          breakerFuture ->
+              // HTTP Client request
+              client.execute(request).setHandler( result -> {
+                // Process result
+                if ( breakerFuture.isComplete() ) {
+                  // Breaker has already fired, this is typically due to the breaker timeout < response time.
+                  // Close the response without processing it to ensure no sockets are leaked
+                  if ( result.succeeded() ) {
+                    ensureClosed(result.result().body());
+                  }
+                }
+                else {
+                  // Run the handler to process the result, the side effect is decodedResultFuture will be marked success/fail
+                  handler.handle(result);
+
+                  // Bubble up the status to the circuit breaker by updating breakerFuture
+                  if (decodedResultFuture.succeeded()) {
+                    breakerFuture.complete(decodedResultFuture.result());
+                  } else {
+                    breakerFuture.fail(decodedResultFuture.cause());
+                  }
+                }
+              }),
+          //
+          // Fallback when breaker is open
+          //
+          throwable -> {
+            Future result = null;
+
+            try {
+              if ( null != fallbackMethod ) {
+                // Invoke the fallback method!
+                result = (Future) that.fallbackMethod.invoke(that.fallbackInstance, argv);
+              }
+            }
+            catch (InvocationTargetException ite) {
+              result = Future.future();
+              result.fail(ite.getCause()); // getCause() is the exception thrown by the function
+            }
+            catch (Throwable t) {
+              result = Future.future();
+              result.fail(t);
+            }
+            finally {
+              if ( null == result ) {
+                // Fallback provided a null response (unimplemented fallback)
+                // Provide a nicer exception class for the breaker exception (default is io.vertx.core.impl.NoStackTraceThrowable)
+                decodedResultFuture.fail( new IllegalStateException( "CircuitBreaker: "+throwable.getMessage()) );
+              }
+              else if ( result.succeeded() ) {
+                decodedResultFuture.complete(result.result()); // Success :-)
+              }
+              else {
+                decodedResultFuture.fail(result.cause()); // Failure :-(
+              }
+            }
+            return null; // null because we use decodedResultFuture to signal completion
+    });
+    }
+
+    // Returns the future that will contain the final results
     return decodedResultFuture;
   }
 
@@ -240,6 +337,7 @@ final class AsynchronousMethodHandler implements MethodHandler {
     private final Logger logger;
     private final Logger.Level logLevel;
     private final boolean decode404;
+    private final CircuitBreaker circuitBreaker;
 
     Factory(
         final VertxHttpClient client,
@@ -247,13 +345,15 @@ final class AsynchronousMethodHandler implements MethodHandler {
         final List<RequestInterceptor> requestInterceptors,
         final Logger logger,
         final Logger.Level logLevel,
-        final boolean decode404) {
+        final boolean decode404,
+        final CircuitBreaker circuitBreaker) {
       this.client = client;
       this.retryer = retryer;
       this.requestInterceptors = requestInterceptors;
       this.logger = logger;
       this.logLevel = logLevel;
       this.decode404 = decode404;
+      this.circuitBreaker = circuitBreaker;
     }
 
     MethodHandler create(
@@ -273,7 +373,8 @@ final class AsynchronousMethodHandler implements MethodHandler {
           buildTemplateFromArgs,
           decoder,
           errorDecoder,
-          decode404);
+          decode404,
+          circuitBreaker);
     }
   }
 
@@ -286,10 +387,12 @@ final class AsynchronousMethodHandler implements MethodHandler {
   private final class ResultHandlerWithRetryer<T> implements Handler<AsyncResult<T>> {
     private final RequestTemplate template;
     private final Retryer retryer;
+    private final Object[] argv;
     private final Future<T> resultFuture = Future.future();
 
-    private ResultHandlerWithRetryer(final RequestTemplate template, final Retryer retryer) {
+    private ResultHandlerWithRetryer(final RequestTemplate template, final Object[] argv, final Retryer retryer) {
       this.template = template;
+      this.argv = argv;
       this.retryer = retryer;
     }
 
@@ -310,7 +413,7 @@ final class AsynchronousMethodHandler implements MethodHandler {
           try {
             this.retryer.continueOrPropagate(retryableException);
             logRetry();
-            ((Future<T>) executeAndDecode(this.template)).setHandler(this);
+            ((Future<T>) executeAndDecode(this.template, argv)).setHandler(this);
           } catch (final RetryableException noMoreRetryAttempts) {
             this.resultFuture.fail(noMoreRetryAttempts);
           }
@@ -328,6 +431,114 @@ final class AsynchronousMethodHandler implements MethodHandler {
      */
     private Future<?> getResultFuture() {
       return this.resultFuture;
+    }
+  }
+
+
+  /**
+   * Locate the fallback instance from the {@code @Fallback} annotation
+   * This may return null if none is available
+   * @return
+   */
+  private Object getFallbackInstance() throws IllegalAccessException, InstantiationException {
+    Object ret = fallbackInstanceCache.get(target.type());
+
+    if (null == ret) {
+      // Cache miss, find the fallback class
+      Class fallbackClass = null;
+
+      for (Annotation annotation : target.type().getAnnotations()) {
+        if (annotation instanceof Fallback) {
+          fallbackClass = ((Fallback) annotation).value();
+          break;
+        }
+      }
+
+      if (null != fallbackClass) {
+        ret = fallbackClass.newInstance();
+        fallbackInstanceCache.put(target.type(), ret);
+      }
+    }
+
+    return ret;
+  }
+
+  /**
+   * Return the fallback method or null if there isn't one available
+   * @param method
+   * @param fallbackInstance
+   * @return
+   */
+  private Method getFallbackMethod(final Method method, final Object fallbackInstance) {
+    Method ret = null;
+
+    if ( null != fallbackInstance ) {
+      // Make sure fallbackInstance is derived from the same interface as our target.type()
+      boolean fallbackInstaceCompatible = false;
+      for( Class iface : fallbackInstance.getClass().getInterfaces() ) {
+        if ( iface.equals(target.type()) ) {
+          fallbackInstaceCompatible = true;
+          break;
+        }
+      }
+
+      // Find the exact method on the fallbackInstance that matches the method argument
+      if ( fallbackInstaceCompatible ) {
+        for( Method m : fallbackInstance.getClass().getDeclaredMethods() ) {
+          // Now match the method to the instance
+          if ( m.getName().equals(method.getName()) ) {
+            if ( m.getReturnType().equals(method.getReturnType())) {
+              if ( m.getParameterCount() == method.getParameterCount() ) {
+                ret = m; // we set to null if there's a mismatch
+                Parameter[] a = m.getParameters();
+                Parameter[] b = method.getParameters();
+                for (int i = 0; i < a.length; i++) {
+                  if ( a[i].getType() != b[i].getType() ) {
+                    ret = null;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+
+          if ( null != ret ) break; // done
+        }
+      }
+    }
+
+    return ret;
+  }
+
+  /**
+   * To enable circuit breaker fallback we need to have the original Method
+   * definition. Unfortunately the core Feign interfaces and factories do not pass
+   * this to a MethodHandler (this class).
+   * Call setMethodDetail with the reflection data for the matching Feign method.
+   * Side-effect: this will also configure fallbackInstance and fallbackMethod
+   * @param method
+   * @throws IllegalArgumentException when the method doesn't match this asynchronous handler
+   */
+  public void updateMethodDetail(Method method) throws IllegalArgumentException {
+    // Validate the method argument matches this handler's configuration
+    try {
+      String methodKey = Feign.configKey(Class.forName(target.type().getName()), method);
+      if ( metadata.configKey().equals(methodKey) ) {
+        // Store the method
+        thisMethod = method;
+        /// Now fetch the fallback instance and method where available
+        fallbackInstance = getFallbackInstance();
+        fallbackMethod = getFallbackMethod(thisMethod, fallbackInstance);
+      }
+      else {
+        // Problem
+        throw new IllegalArgumentException("Method key '"+methodKey+"' does not match this handler's key signature '"+ metadata.configKey()+"'");
+      }
+    } catch (ClassNotFoundException e) {
+      // Problem
+      throw new IllegalArgumentException("The target for this handler cannot be found: "+target.type().getName());
+    } catch (IllegalAccessException | InstantiationException e) {
+      throw new IllegalArgumentException("A fallback class was found but could not be instantiated for "+target.type().getName());
     }
   }
 }

--- a/src/main/java/feign/Fallback.java
+++ b/src/main/java/feign/Fallback.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feign;
+
+import java.lang.annotation.*;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to designate the fallback class for
+ * VertxFeign when using {@link io.vertx.circuitbreaker.CircuitBreaker}
+ * All methods in the interface should be implemented in the
+ * designated class.
+ * Example:
+ *    {@code @Fallback( IcecreamServiceApiFallback.class )}
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Fallback {
+  /**
+   * @see Fallback
+   */
+  Class<?> value() default void.class;
+}

--- a/src/test/java/feign/vertx/VertxCircuitBreakerTest.java
+++ b/src/test/java/feign/vertx/VertxCircuitBreakerTest.java
@@ -1,0 +1,304 @@
+package feign.vertx;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import feign.FeignException;
+import feign.Logger;
+import feign.Request;
+import feign.VertxFeign;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.slf4j.Slf4jLogger;
+import feign.vertx.testcase.IcecreamServiceApi;
+import feign.vertx.testcase.domain.Bill;
+import feign.vertx.testcase.domain.Flavor;
+import feign.vertx.testcase.domain.IceCreamOrder;
+import feign.vertx.testcase.domain.OrderGenerator;
+import io.vertx.circuitbreaker.CircuitBreaker;
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test the use of the Vertx CircuitBreaker with Feign
+ */
+@RunWith(VertxUnitRunner.class)
+public class VertxCircuitBreakerTest {
+  private Vertx vertx = Vertx.vertx();
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(8089);
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private String flavorsStr;
+
+  private CircuitBreaker breaker;
+  private IcecreamServiceApi client;
+
+  private OrderGenerator generator = new OrderGenerator();
+
+  /**
+   * Configure Mock response data, circuit breaker, and Feign client.
+   * @throws Exception
+   */
+  @Before
+  public void setUp() throws Exception {
+    /* Given */
+    flavorsStr = Arrays
+              .stream(Flavor.values())
+              .map(flavor -> "\"" + flavor + "\"")
+              .collect(Collectors.joining(", ", "[ ", " ]"));
+
+    breaker = CircuitBreaker.create("breaker1", vertx,
+                                      new CircuitBreakerOptions() // DO NOT change these values without considering the test cases below
+                                              .setMaxFailures(2) // number of failure before opening the circuit
+                                              .setTimeout(1000) // consider a failure if the operation does not succeed in time
+                                              .setFallbackOnFailure(true) // Required if we want the fallback to activate
+                                              .setResetTimeout(10000) // time spent in open state before attempting to re-try
+                                   );
+
+    client = VertxFeign
+            .builder()
+            .vertx(vertx)
+            .options( new Request.Options( 10000, 10000))
+            .encoder(new JacksonEncoder(TestUtils.MAPPER))
+            .decoder(new JacksonDecoder(TestUtils.MAPPER))
+            .logger(new Slf4jLogger())
+            .logLevel(Logger.Level.FULL)
+            .circuitBreaker(breaker) // <--- BREAKER
+            .target(IcecreamServiceApi.class, "http://localhost:8089");
+
+  }
+
+  /**
+   * Ensure WireMock doesn't have pending requests queued (useful after failure testing)
+   * Ensure the circuit breaker doesn't carry a lingering state
+   * @throws InterruptedException
+   */
+  @After
+  public void resetWireMock() throws InterruptedException {
+      // Wait to ensure any pending timers have a chance to fire
+      // For example: The breaker timer fires despite a successful response, indicating a bug
+      Thread.sleep(4000);
+      // Now reset WireMock and the Break for the next test
+      wireMockRule.resetRequests();
+  }
+
+  /**
+   * Test the circuit breaker during a happy-path immediate successful response
+   * @param context Test Context
+   */
+  @Test
+  public void testBreakerSuccess(TestContext context) {
+
+    stubFor(get(urlEqualTo("/icecream/flavors"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(flavorsStr)));
+
+    Async async = context.async();
+
+    client.getAvailableFlavors().setHandler(res -> {
+      if (res.succeeded()) {
+        try {
+          Collection<Flavor> flavors = res.result();
+          assertThat(flavors)
+              .hasSize(Flavor.values().length)
+              .containsAll(Arrays.asList(Flavor.values()));
+          async.complete();
+        } catch (Throwable exception) {
+          context.fail(exception);
+        }
+      } else {
+        context.fail(res.cause());
+      }
+    });
+  }
+
+  /**
+   * Test the circuit breaker with a slow responding circuit that exceeds the timeout.
+   * This is the simple test as the REST request has no arguments
+   * @param context Test Context
+   */
+  @Test
+  public void testBreakerFallbackSimple(TestContext context) throws InterruptedException {
+
+    stubFor(get(urlEqualTo("/icecream/flavors"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                        .withFixedDelay(2000) // Longer than the 1000ms breaker timeout :-)
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(flavorsStr)));
+
+    Async async = context.async();
+
+    client.getAvailableFlavors().setHandler(res -> {
+      if (res.succeeded()) {
+        try {
+          Collection<Flavor> flavors = res.result();
+          assertThat(flavors)
+              .hasSize(1)
+              .containsAll(Arrays.asList(Flavor.BANANA));
+          async.complete();
+        } catch (Throwable exception) {
+          context.fail(exception);
+        }
+      } else {
+        context.fail(res.cause());
+      }
+    });
+  }
+
+  /**
+   * Test the circuit breaker with a slow responding circuit that exceeds the timeout.
+   * This is the complex test as the REST request has one or more nontivial arguments
+   * along with a non-trival response.
+   * @param context Test Context
+   */
+  @Test
+  public void testBreakerFallbackComplex(TestContext context) throws InterruptedException {
+    /* Given */
+    IceCreamOrder order = generator.generate();
+    Bill bill = Bill.makeBill(order);
+    String orderStr = TestUtils.encodeAsJsonString(order);
+    String billStr = TestUtils.encodeAsJsonString(bill);
+
+    stubFor(post(urlEqualTo("/icecream/orders"))
+        .withHeader("Content-Type", equalTo("application/json"))
+        .withHeader("Accept", equalTo("application/json"))
+        .withRequestBody(equalToJson(orderStr))
+        .willReturn(aResponse()
+                    .withFixedDelay(2000) // Longer than the 1000ms breaker timeout :-)
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(billStr)));
+
+    Async async = context.async();
+
+    // Since we're expecting our fallback method to be executed, rather than
+    // the mock above. We will discount the bill by 10% to match the fallback logic.
+    bill.setPrice(bill.getPrice()*0.90f);
+
+    /* When */
+    client.makeOrder(order).setHandler(res -> {
+
+      /* Then */
+      if (res.succeeded()) {
+        try {
+          Assertions.assertThat(res.result())
+              .isEqualToComparingFieldByFieldRecursively(bill);
+          async.complete();
+        } catch (Throwable exception) {
+          context.fail(exception);
+        }
+      } else {
+        context.fail(res.cause());
+      }
+    });
+  }
+
+  /**
+   * Test the circuit breaker with a slow responding circuit that exceeds the timeout.
+   * This test ensures the framework can handle a fallback method that throws an unchecked exception
+   * @param context Test Context
+   */
+  @Test
+  public void testBreakerFallbackException(TestContext context) throws InterruptedException {
+    /* Given */
+    IceCreamOrder order = generator.generate();
+    int orderId = order.getId();
+    String orderStr = TestUtils.encodeAsJsonString(order);
+
+    stubFor(get(urlEqualTo("/icecream/orders/" + orderId))
+        .withHeader("Accept", equalTo("application/json"))
+        .willReturn(aResponse()
+                    .withStatus(200)
+                    .withFixedDelay(2000) // Longer than the 1000ms breaker timeout :-)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(orderStr)));
+
+
+    Async async = context.async();
+
+    /* When */
+    client.findOrder(orderId).setHandler(res -> {
+
+      /* Then */
+      if (res.failed()) {
+        try {
+          Assertions.assertThat(res.cause())
+              .isInstanceOf(IllegalAccessError.class);
+
+          async.complete();
+        } catch (Throwable exception) {
+          context.fail(exception);
+        }
+      } else {
+        context.fail(res.cause());
+      }
+    });
+  }
+
+  /**
+   * Test the circuit breaker with a slow responding circuit that exceeds the timeout.
+   * This test exercises a fallback method that has not been implemented (return null)
+   * @param context Test Context
+   */
+  @Test
+  public void testBreakerFallbackUndefined(TestContext context) throws InterruptedException {
+    /* Given */
+    Bill bill = Bill.makeBill(generator.generate());
+    String billStr = TestUtils.encodeAsJsonString(bill);
+
+    stubFor(post(urlEqualTo("/icecream/bills/pay"))
+        .withHeader("Content-Type", equalTo("application/json"))
+        .withRequestBody(equalToJson(billStr))
+        .willReturn(aResponse()
+                    .withStatus(200)
+                    .withFixedDelay(2000) // Longer than the 1000ms breaker timeout :-)
+                    ));
+
+    Async async = context.async();
+
+    /* When */
+    client.payBill(bill).setHandler(res -> {
+      /* Then */
+      if (res.failed()) {
+        try {
+          Assertions.assertThat(res.cause())
+              .isInstanceOf(IllegalStateException.class);
+
+          Assertions.assertThat(res.cause().getMessage())
+              .containsIgnoringCase("CircuitBreaker");
+
+          async.complete();
+        } catch (Throwable exception) {
+          context.fail(exception);
+        }
+      } else {
+        context.fail(res.cause());
+      }
+    });
+  }
+
+}

--- a/src/test/java/feign/vertx/testcase/IcecreamServiceApi.java
+++ b/src/test/java/feign/vertx/testcase/IcecreamServiceApi.java
@@ -1,5 +1,6 @@
 package feign.vertx.testcase;
 
+import feign.Fallback;
 import feign.Headers;
 import feign.Param;
 import feign.RequestLine;
@@ -17,6 +18,7 @@ import java.util.Collection;
  * @author Alexei KLENIN
  */
 @Headers({ "Accept: application/json" })
+@Fallback( IcecreamServiceApiFallback.class )
 public interface IcecreamServiceApi {
 
   @RequestLine("GET /icecream/flavors")

--- a/src/test/java/feign/vertx/testcase/IcecreamServiceApiFallback.java
+++ b/src/test/java/feign/vertx/testcase/IcecreamServiceApiFallback.java
@@ -1,0 +1,75 @@
+package feign.vertx.testcase;
+
+import feign.vertx.testcase.domain.Bill;
+import feign.vertx.testcase.domain.Flavor;
+import feign.vertx.testcase.domain.IceCreamOrder;
+import feign.vertx.testcase.domain.Mixin;
+import io.vertx.core.Future;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class IcecreamServiceApiFallback implements IcecreamServiceApi {
+  /**
+   * Fallback for getAvailableFlavors(). It will default to just Banana
+   * @return
+   */
+  @Override
+  public Future<Collection<Flavor>> getAvailableFlavors() {
+    Future ret = Future.future();
+
+    ret.complete(Arrays.asList(Flavor.BANANA)); // We will fallback to just Banana
+
+    return ret;
+  }
+
+  @Override
+  public Future<Collection<Mixin>> getAvailableMixins() {
+    return null;
+  }
+
+  /**
+   * This fallback receives an order and provides a price with an
+   * automatic 10% off due to the real REST endpoint not being available
+   *
+   * @param order
+   * @return Bill
+   */
+  @Override
+  public Future<Bill> makeOrder(IceCreamOrder order) {
+    Future ret = Future.future();
+
+    // Verify the order is defined
+    if ( null == order ) {
+      throw new IllegalArgumentException("Order is invalid");
+    }
+
+    // Verify the order is valid (should never trip)
+    if ( null == order.getBalls() || order.getBalls().size() < 0) {
+      throw new IllegalArgumentException("Order has an invalid number of balls");
+    }
+
+    // We set a special fallback price of 10% off
+    Bill bill = Bill.makeBill(order);
+    bill.setPrice(bill.getPrice()*0.90f);
+
+    ret.complete(bill);
+
+    return ret;
+  }
+
+  /**
+   * Test exception handling
+   * @param orderId
+   * @return
+   */
+  @Override
+  public Future<IceCreamOrder> findOrder(int orderId) {
+    throw new IllegalAccessError("This is to test the fallback handler exception handling logic");
+  }
+
+  @Override
+  public Future<Void> payBill(Bill bill) {
+    return null;
+  }
+}


### PR DESCRIPTION
I've added the option to add a circuit breaker to the Feign-Vertx client.

I've also added an optional @Fallback annotation which can be used to specify open-circuit behavior using zero boilerplate.

See unit test Class VertxCircuitBreakerTest

Hope you like the enhancement!