### PR TITLE
support a timeout in the http request

### DIFF
--- a/src/main/java/feign/AsynchronousMethodHandler.java
+++ b/src/main/java/feign/AsynchronousMethodHandler.java
@@ -7,11 +7,13 @@ import feign.codec.ErrorDecoder;
 import feign.vertx.VertxHttpClient;
 import io.vertx.core.Future;
 import io.vertx.core.VertxException;
+import io.vertx.core.impl.NoStackTraceThrowable;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import static feign.FeignException.errorExecuting;
@@ -146,7 +148,7 @@ final class AsynchronousMethodHandler implements MethodHandler {
               }
             },
             failure -> {
-              if (failure instanceof VertxException) {
+              if (failure instanceof VertxException || failure instanceof TimeoutException) {
                 return Future.failedFuture(failure);
               } else if (failure.getCause() instanceof IOException) {
                 final long elapsedTime = Duration.between(start, Instant.now()).toMillis();

--- a/src/main/java/feign/VertxFeign.java
+++ b/src/main/java/feign/VertxFeign.java
@@ -1,5 +1,6 @@
 package feign;
 
+import static feign.Util.checkArgument;
 import static feign.Util.checkNotNull;
 import static feign.Util.isDefault;
 
@@ -88,6 +89,7 @@ public final class VertxFeign extends Feign {
     private Decoder decoder = new Decoder.Default();
     private ErrorDecoder errorDecoder = new ErrorDecoder.Default();
     private HttpClientOptions options = new HttpClientOptions();
+    private long timeout = -1;
     private boolean decode404;
 
     /** Unsupported operation. */
@@ -257,6 +259,20 @@ public final class VertxFeign extends Feign {
     }
 
     /**
+     * Configures the amount of time in milliseconds after which if the request does not return any data within the timeout
+     * period an {@link java.util.concurrent.TimeoutException} fails the request.
+     * <p>
+     * Setting zero or a negative {@code value} disables the timeout.
+     *
+     * @param timeout The quantity of time in milliseconds.
+     * @return this builder
+     */
+    public Builder timeout(long timeout) {
+      this.timeout = timeout;
+      return this;
+    }
+
+    /**
      * Adds a single request interceptor to the builder.
      *
      * @param requestInterceptor  request interceptor to add
@@ -325,7 +341,7 @@ public final class VertxFeign extends Feign {
     public VertxFeign build() {
       checkNotNull(this.vertx, "Vertx instance wasn't provided in VertxFeign builder");
 
-      final VertxHttpClient client = new VertxHttpClient(vertx, this.options);
+      final VertxHttpClient client = new VertxHttpClient(vertx, this.options, timeout);
       final AsynchronousMethodHandler.Factory methodHandlerFactory =
           new AsynchronousMethodHandler.Factory(client, retryer, requestInterceptors, logger,
               logLevel, decode404);

--- a/src/main/java/feign/vertx/VertxHttpClient.java
+++ b/src/main/java/feign/vertx/VertxHttpClient.java
@@ -32,6 +32,7 @@ import java.util.stream.StreamSupport;
 @SuppressWarnings("unused")
 public final class VertxHttpClient {
   private final HttpClient httpClient;
+  private long timeout = -1;
 
   /**
    * Constructor from {@link Vertx} instance and HTTP client options.
@@ -43,6 +44,17 @@ public final class VertxHttpClient {
     checkNotNull(vertx, "Argument vertx must not be null");
     checkNotNull(options, "Argument options must be not null");
     this.httpClient = vertx.createHttpClient(options);
+  }
+
+  /**
+   * Constructor from {@link Vertx} instance, HTTP client options and request timeout.
+   * @param vertx vertx instance
+   * @param options HTTP options
+   * @param timeout request timeout
+   */
+  public VertxHttpClient(final Vertx vertx, final HttpClientOptions options, long timeout) {
+    this(vertx, options);
+    this.timeout = timeout;
   }
 
   /**
@@ -102,7 +114,8 @@ public final class VertxHttpClient {
         .request(HttpMethod.valueOf(request.httpMethod().name()),
             port,
             host,
-            requestUri);
+            requestUri)
+        .timeout(timeout);
 
     /* Add headers to request */
     for (final Map.Entry<String, Collection<String>> header : request.headers().entrySet()) {


### PR DESCRIPTION
usage:
VertxFeign
          .builder()
          .vertx(vertx)
          .decoder(new JacksonDecoder(TestUtils.MAPPER))
          .timeout(1000)
          .options(new HttpClientOptions().setLogActivity(true))
          .logger(new Slf4jLogger())
          .logLevel(Logger.Level.FULL)
          .target(IcecreamServiceApi.class, wireMock.baseUrl());