### PR TITLE
Fix nondeterminism issue in IceCreamOrder test fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 feign-vertx.iml
 target
+
+# NonDex generated files
+.nondex

--- a/src/test/java/feign/vertx/testcase/domain/IceCreamOrder.java
+++ b/src/test/java/feign/vertx/testcase/domain/IceCreamOrder.java
@@ -2,7 +2,7 @@ package feign.vertx.testcase.domain;
 
 import java.time.Instant;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -26,7 +26,7 @@ public class IceCreamOrder {
   IceCreamOrder(final Instant orderTimestamp) {
     this.id = ThreadLocalRandom.current().nextInt();
     this.balls = new HashMap<>();
-    this.mixins = new HashSet<>();
+    this.mixins = new LinkedHashSet<>();
     this.orderTimestamp = orderTimestamp;
   }
 


### PR DESCRIPTION
Fixes issues found by [NonDex](https://github.com/TestingResearchIllinois/NonDex), caused by the use of a `HashSet` in the test fixtures, leading to nondeterministic creation of ordered JSON arrays. This causes `WireMock`'s JSON equality matching to fail due to array ordering differences.

This PR enforces ordering in the `IceCreamOrder::mixins` variable by using a `LinkedHashSet`, thus guaranteeing that any JSON string generated using the same `IceCreamOrder` has a deterministically serialized `mixins` value.

For example, before this fix, the _same_ `IceCreamOrder` may be serialized as any of the following:
```json
{ "mixins": [ "COOKIES", "NUTS", "RAINBOW" ], ... }
{ "mixins": [ "NUTS", "COOKIES", "RAINBOW" ], ... }
{ "mixins": [ "COOKIES", "RAINBOW", "NUTS" ], ... }
{ "mixins": [ "RAINBOW", "COOKIES", "NUTS" ], ... }
...
```

Any difference in repeated serialization would cause the `equalToJson` in WireMock to fail, causing an erroneous test failure.

To verify the issue, running NonDex via Maven can be done as follows:
```bash
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=*VertxHttpClientTest*WhenMakePostRequest* -DnondexRuns=10
```

Depending on seeding, you may need to re-run this command or increase `-DnondexRuns` before a test failure is observed.